### PR TITLE
MWPW-166682 Helix 5 upgrade fix - revert loc sidekick url

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -72,7 +72,7 @@
       "id": "localize-2",
       "title": "Localize (V2)",
       "environments": [ "edit" ],
-      "url": "https://main--da-bacom-blog--adobecom.aem.live/tools/loc?milolibs=locui",
+      "url": "https://main--da-bacom-blog--adobecom.hlx.live/tools/loc?milolibs=locui",
       "passReferrer": true,
       "passConfig": true,
       "includePaths": [ "**.xlsx**" ]


### PR DESCRIPTION
* Returns loc sidekick url to .hlx. because loc is not yet ready for helix 5

Resolves: [MWPW-166682](https://jira.corp.adobe.com/browse/MWPW-166682)

**Test URLs:**
- Before: https://main--da-bacom-blog--adobecom.aem.live/?martech=off
- After: https://hlx5-loc--da-bacom-blog--adobecom.aem.live/blog/?martech=off
