### PR TITLE
MWPW-166682 [Helix 5 Migration] Revert sidekick config

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -72,7 +72,7 @@
       "id": "localize-2",
       "title": "Localize (V2)",
       "environments": [ "edit" ],
-      "url": "https://main--da-bacom-blog--adobecom.hlx.live/tools/loc?milolibs=locui",
+      "url": "https://main--bacom-blog--adobecom.hlx.page/tools/loc?milolibs=locui",
       "passReferrer": true,
       "passConfig": true,
       "includePaths": [ "**.xlsx**" ]
@@ -82,7 +82,7 @@
       "id": "floodgate",
       "title": "Floodgate",
       "environments": [ "edit" ],
-      "url": "https://main--da-bacom-blog--adobecom.aem.live/tools/floodgate?milolibs=floodgateui",
+      "url": "https://main--bacom-blog--adobecom.hlx.page/tools/floodgate?milolibs=floodgateui",
       "passReferrer": true,
       "passConfig": true,
       "includePaths": [ "**.xlsx**" ]
@@ -92,7 +92,7 @@
       "title": "Tag Selector",
       "id": "tag-selector",
       "environments": ["edit"],
-      "url": "https://main--da-bacom-blog--adobecom.aem.live/tools/tag-selector",
+      "url": "https://main--da-bacom-blog--adobecom.hlx.live/tools/tag-selector",
       "isPalette": true,
       "paletteRect": "top: 150px; left: 7%; height: 675px; width: 85vw;"
     },
@@ -101,7 +101,7 @@
       "id": "bulk",
       "title": "Bulk operations",
       "environments": [ "edit", "dev", "preview", "live" ],
-      "url": "https://main--da-bacom-blog--adobecom.aem.live/tools/bulk"
+      "url": "https://main--da-bacom-blog--adobecom.hlx.live/tools/bulk"
     },
     {
       "id": "da-tags",


### PR DESCRIPTION
* Removes .aem. urls from sidekick
* URLs generated upon preview should be hlx.page (I don't see a way to test this in DA)
* Sidekick tools should not have .aem. links. Will be prod or hlx urls.

Resolves: [MWPW-166682](https://jira.corp.adobe.com/browse/MWPW-166682)

**Test URLs:**
- Before: https://main--da-bacom-blog--adobecom.hlx.live/blog/?martech=off
- After: https://hlx5-sidekick--da-bacom-blog--adobecom.hlx.live/blog/?martech=off

- Before: https://main--da-bacom-blog--adobecom.aem.live/blog/?martech=off
- After: https://hlx5-sidekick--da-bacom-blog--adobecom.aem.live/blog/?martech=off
