### PR TITLE
MWPW-166682 [Helix 5 Migration] Set preview url

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -2,6 +2,8 @@
   "project": "BACOM-BLOG",
   "editUrlLabel": "Document Authoring",
   "editUrlPattern": "https://da.live/edit#/{{org}}/{{site}}{{pathname}}",
+  "previewHost": "main--da-bacom-blog--adobecom.hlx.page",
+  "liveHost": "main--da-bacom-blog--adobecom.hlx.live",
   "plugins": [
     {
       "id": "library",


### PR DESCRIPTION
* Explicitly set the sidekick preview and live link config to .hlx.
* Will have no change for authors
* Allows us to control the change from .hlx. to .aem. in sidekick instead of it being inferred from the config

Resolves: [MWPW-166682](https://jira.corp.adobe.com/browse/MWPW-166682)

**Test URLs:**
- Before: https://main--da-bacom-blog--adobecom.aem.live/?martech=off
- After: https://hlx5-preview-link--da-bacom-blog--adobecom.aem.live/?martech=off
*This is not testable. DA preview/publish uses the main branch config with no option to change for testing purposes.