### PR TITLE
MWPW-169637 Fix Article Header Video Size

### DIFF
--- a/blog/scripts/scripts.js
+++ b/blog/scripts/scripts.js
@@ -67,7 +67,8 @@ async function buildArticleHeader(el) {
   const media = h1.nextElementSibling?.querySelector('picture, a') || el.querySelector('picture');
   const caption = getImageCaption(media);
   const mediaContainer = document.createElement('div');
-  mediaContainer.append(media, caption);
+  mediaContainer.append(media);
+  if (caption) { mediaContainer.append(caption); }
   const author = getMetadata('author') || 'Adobe Communications Team';
   const { locale } = getConfig();
   const authorURL = getMetadata('author-url') || (author ? `${locale.contentRoot}/authors/${author.replace(/[^0-9a-z]/gi, '-').toLowerCase()}` : null);

--- a/blog/styles/styles.css
+++ b/blog/styles/styles.css
@@ -94,7 +94,8 @@ main p picture img {
   --featured-media-height: 440px;
 }
 
-.article-header .article-feature-image {
+.article-header .article-feature-image,
+.article-header .article-feature-video {
   padding: 0;
   margin: auto;
   width: 100%;
@@ -197,7 +198,8 @@ main .article-header .article-category p {
     padding-bottom: var(--featured-media-height);
   }
 
-  main .article-feature-video lite-vimeo {
+  main .article-feature-video lite-vimeo,
+  main .article-feature-video video {
     height: var(--featured-media-height);
     width: 100%;
   }


### PR DESCRIPTION
* Match video size to image size in Article Header
* Fix vimeo and youtube not working

Resolves: [MWPW-169637](https://jira.corp.adobe.com/browse/MWPW-169637)

**Test URLs:**
MP4:

- Before: https://main--da-bacom-blog--adobecom.aem.live/drafts/methomas/article-header-mp4
- After: https://video-size--da-bacom-blog--adobecom.aem.page/drafts/methomas/article-header-mp4

AdobeTV:
- Before: https://main--da-bacom-blog--adobecom.aem.live/drafts/methomas/article-header-adobetv
- After: https://video-size--da-bacom-blog--adobecom.aem.page/drafts/methomas/article-header-adobetv

Vimeo:
- Before: https://main--da-bacom-blog--adobecom.aem.live/drafts/methomas/article-header-vimeo
- After: https://video-size--da-bacom-blog--adobecom.aem.page/drafts/methomas/article-header-vimeo

Youtube:
- Before: https://main--da-bacom-blog--adobecom.aem.live/drafts/methomas/article-header-youtube
- After: https://video-size--da-bacom-blog--adobecom.aem.page/drafts/methomas/article-header-youtube