### PR TITLE
MWPW-166682 Update sidekick da-edit

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -65,7 +65,8 @@
     {
       "id": "locales",
       "title": "Locales",
-      "environments": ["da-edit"],
+      "environments": ["edit"],
+      "daLibrary": true,
       "icon": "https://main--da-bacom-blog--adobecom.aem.live/media/media_1c385be465401986f20e49857dc80f772c7f77d09.png",
       "path": "/tools/locale-nav/locale-nav.html"
     },
@@ -108,7 +109,8 @@
     {
       "id": "da-tags",
       "title": "Tag Browser",
-      "environments": ["da-edit"],
+      "environments": ["edit"],
+      "daLibrary": true,
       "icon": "https://main--da-bacom-blog--adobecom.aem.live/media/media_16dd3261cd73df7adf30ed02b31d7d58ada82a3f0.png",
       "path": "/tools/tags.html"
     }


### PR DESCRIPTION
* Replace old `da-edit` (which is not helix 5 compatible) with new schema
* https://github.com/adobe/da-live/wiki/DA-App-SDK#optional-toolssidekickconfigjson

Resolves: [MWPW-166682](https://jira.corp.adobe.com/browse/MWPW-166682)

**Test URLs:**
- Before: https://da.live/edit#/adobecom/da-bacom-blog/drafts/methomas/article-header-adobetv
- After: https://da.live/edit?ref=methomas-da-edit#/adobecom/da-bacom-blog/drafts/methomas/article-header-adobetv

Just needs regression testing on the library. The "Locales" and "Tag Browser" tools should still work.