### PR TITLE
Fix sidekick configs

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -65,7 +65,8 @@
     {
       "id": "locales",
       "title": "Locales",
-      "environments": ["da-edit"],
+      "daLibrary": true,
+      "environments": ["edit"],
       "icon": "https://main--da-bacom-blog--adobecom.aem.live/media/media_1c385be465401986f20e49857dc80f772c7f77d09.png",
       "path": "/tools/locale-nav/locale-nav.html"
     },
@@ -108,7 +109,8 @@
     {
       "id": "da-tags",
       "title": "Tag Browser",
-      "environments": ["da-edit"],
+      "daLibrary": true,
+      "environments": ["edit"],
       "icon": "https://main--da-bacom-blog--adobecom.aem.live/media/media_16dd3261cd73df7adf30ed02b31d7d58ada82a3f0.png",
       "path": "/tools/tags.html"
     }


### PR DESCRIPTION
### Description
There's a validation error using `da-edit` since it doesn't match the configuration schema. Hence configs are currently can't be "auto-migrated" and the sheet based configs on da-bacom-blog are broken. We can still manually push it via the API and fix it there - but we should properly fix this in the codebase.

**Test URLs:**
- Before: https://main--da-bacom-blog--adobecom.aem.live/?martech=off
- After: https://fix-sidekick-configs--da-bacom-blog--adobecom.aem.live/?martech=off
