### PR TITLE
MWPW-170276 Added support for multiple environments of MS Apps

### DIFF
--- a/tools/ms-apps/daUtils.js
+++ b/tools/ms-apps/daUtils.js
@@ -13,8 +13,8 @@ import DA_SDK from 'https://da.live/nx/utils/sdk.js';
         appHost = 'https://milostudio-stage--milo--adobecom.aem.page';
         break;
       case 'dev':
-      case 'local':
         appHost = 'https://milostudio-dev--milo--adobecom.aem.page';
+        break;
     }
     window.location.replace(
       `${appHost}/tools/da-apps/ms-apps.html?path=${redirectPath}&tenant=${repo}&ref=${ref}&token=${token}`

--- a/tools/ms-apps/daUtils.js
+++ b/tools/ms-apps/daUtils.js
@@ -4,10 +4,20 @@ import DA_SDK from 'https://da.live/nx/utils/sdk.js';
 (async () => {
   try {
     const { context, token } = await DA_SDK;
-    const { repo, path } = context;
+    const { repo, path, ref } = context;
     const redirectPath = path.split('/').pop();
+
+    let appHost = 'https://milostudio--milo--adobecom.aem.page';
+    switch (ref) {
+      case 'stage':
+        appHost = 'https://milostudio-stage--milo--adobecom.aem.page';
+        break;
+      case 'dev':
+      case 'local':
+        appHost = 'https://milostudio-dev--milo--adobecom.aem.page';
+    }
     window.location.replace(
-      `https://milostudio--milo--adobecom.aem.page/tools/da-apps/ms-apps.html?path=${redirectPath}&tenant=${repo}&token=${token}`
+      `${appHost}/tools/da-apps/ms-apps.html?path=${redirectPath}&tenant=${repo}&ref=${ref}&token=${token}`
     );
   } catch (error) {
     console.error('Error initializing DA_SDK:', error);


### PR DESCRIPTION
Based on "ref" from context in DA-SDK, different environments of centrally hosted MS Apps could be invoked


Resolves: [MWPW-170276](https://jira.corp.adobe.com/browse/MWPW-170276)

**Test URLs:**
- Before: https://da.live/app/adobecom/da-bacom-blog/tools/ms-apps/search
- After: https://da.live/app/adobecom/da-bacom-blog/tools/ms-apps/search?ref=stage

<img width="1008" alt="Screenshot 2025-04-08 at 2 16 42 AM" src="https://github.com/user-attachments/assets/528b1381-06a4-44f3-a210-9b4314b1d87a" />

