### PR TITLE
MWPW-188278: Align head-loaded SSR flag with da-bacom pattern

### DIFF
--- a/head.html
+++ b/head.html
@@ -1,4 +1,5 @@
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
+<meta name="head-loaded" content="false"/>
 <script src="/blog/scripts/fallback.js" nomodule></script>
 <script type="importmap">
   {
@@ -17,7 +18,8 @@
     return branch.includes('--') ? `https://${branch}.aem.live/libs` : `https://${branch}--milo--adobecom.aem.live/libs`;
   })();
 
-  const ssrFlag = document.getElementById('page-load-ok-milo')
+  const flagMeta = document.querySelector('meta[name="head-loaded"]');
+  const ssrFlag = flagMeta?.content === 'true';
 
   if (!ssrFlag) {
     const miloStyles = document.createElement('link');
@@ -42,10 +44,12 @@
     "url": window.location.href 
   }
 
-  const jsonLD = document.createElement('script');
-  jsonLD.setAttribute('type', 'application/ld+json');
-  jsonLD.innerText = JSON.stringify(schema);
-  sheetSchema ? sheetSchema.after(jsonLD) : document.head.append(jsonLD);
+  if (!ssrFlag) {
+    const jsonLD = document.createElement('script');
+    jsonLD.setAttribute('type', 'application/ld+json');
+    jsonLD.innerText = JSON.stringify(schema);
+    sheetSchema ? sheetSchema.after(jsonLD) : document.head.append(jsonLD);
+  }
 
   (() => {
     function buildLink(language, url) {
@@ -127,6 +131,7 @@
     }
   })();
 
+  flagMeta.content = 'true';
 </script>
 <script src="/blog/scripts/scripts.js" type="module"></script>
 <style>body { display: none; }</style>


### PR DESCRIPTION
* Adds a meta element that will have it's content modified at the end of the script tag. When content is served with server side rendering from tokowaka, it will prevent any duplication that would occur should the script be run again, like when spoofing headers in the browser. 

Resolves: [MWPW-188278](https://jira.corp.adobe.com/browse/MWPW-188278)

**Test URLs:**
- Before: https://main--da-bacom-blog--adobecom.aem.live/blog/?martech=off
- After: https://ssr-flag--da-bacom-blog--adobecom.aem.live/blog/?martech=off

## Verification Steps

- Go to the test page
- Inspect the `<head>` element, notice no new links
- Go to the network tab
- Click on "More network conditions"
- Scroll down and enable "Custom User Agent" 
- Enter: "ChatGPT-User"
- Reload
- Inspect the `<head>`
- Notice links 
- Ensure there is no link duplication

## Additional testing example with video:
https://wiki.corp.adobe.com/spaces/WP4/pages/3747684013/Adding+Hreflang+Link+Block+Functionality#AddingHreflangLinkBlockFunctionality-Testing

## Implementation doc
https://wiki.corp.adobe.com/spaces/WP4/pages/3747684013/Adding+Hreflang+Link+Block+Functionality

