### PR TITLE
MWPW-196414: upgrade Node.js from 20.x to 24.x

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [24.x]
     steps:
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
## Summary
- Upgrades Node.js from 20.x to 24.x in `.github/workflows/run-tests.yaml`
- Node 20 reaches EOL April 30, 2026 (flagged by Kodiak security scan)
- Per ticket guidance: skipping Node 22 (EOL April 2027), going straight to Node 24 (Active LTS through April 2028)

## Test Plan
- [x] All 17 unit tests pass locally on Node 24

Closes MWPW-196414

🤖 Generated with [Claude Code](https://claude.com/claude-code)