### PR TITLE
MWPW-183849: Add blog-author block

### DIFF
--- a/blog/blocks/blog-author/blog-author.css
+++ b/blog/blocks/blog-author/blog-author.css
@@ -50,8 +50,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 40px;
-  height: 40px;
+  width: 28px;
+  height: 28px;
   background: var(--color-gray-700, #2c2c2c);
   border-radius: 8px;
   color: #fff;
@@ -64,8 +64,9 @@
 
 .blog-author-social .icon svg {
   display: block;
-  width: 22px;
-  height: 22px;
+  width: 16px;
+  height: 16px;
+  transform: translateY(-2px);
 }
 
 .blog-author-subscribe {

--- a/blog/blocks/blog-author/blog-author.css
+++ b/blog/blocks/blog-author/blog-author.css
@@ -69,31 +69,6 @@
   transform: translateY(-2px);
 }
 
-.blog-author-subscribe {
-  background: var(--color-gray-100, #f5f5f5);
-  border-radius: 8px;
-  padding: 16px;
-  margin-top: 16px;
-}
-
-.blog-author-subscribe p {
-  font-size: 18px;
-  font-weight: 700;
-  margin: 0 0 16px;
-}
-
-.blog-author-subscribe-btn {
-  display: inline-block;
-  border: 2px solid var(--color-gray-700, #2c2c2c);
-  border-radius: 20px;
-  padding: 6px 20px;
-  font-size: 15px;
-  font-weight: 600;
-  text-decoration: none;
-  text-transform: capitalize;
-  color: inherit;
-}
-
 @media (min-width: 600px) {
   .blog-author {
     padding: 56px 32px;
@@ -184,8 +159,7 @@
   .blog-author-name,
   .blog-author-title,
   .blog-author-description,
-  .blog-author-social,
-  .blog-author-subscribe {
+  .blog-author-social {
     grid-column: 2;
   }
 }

--- a/blog/blocks/blog-author/blog-author.css
+++ b/blog/blocks/blog-author/blog-author.css
@@ -104,15 +104,76 @@
   color: inherit;
 }
 
-/* Tablet 600px+: image becomes circle on left, content stacks on right */
+/* Small tablet 600-767px: stacked, 300x300 image */
 @media (min-width: 600px) {
   .blog-author {
+    padding: 56px 32px;
+  }
+
+  .blog-author-image picture {
+    width: 300px;
+  }
+
+  .blog-author-image img {
+    width: 300px;
+    height: 300px;
+    aspect-ratio: auto;
+  }
+
+  /* Full-width variant: image fills content area width */
+  .blog-author.full-width .blog-author-image picture {
+    width: 100%;
+  }
+
+  .blog-author.full-width .blog-author-image img {
+    width: 100%;
+    height: 300px;
+  }
+
+  .blog-author-social {
+    gap: 16px;
+  }
+}
+
+/* Tablet 768-1199px: stacked, 328x328 image, 48px side padding */
+@media (min-width: 768px) {
+  .blog-author {
+    padding: 56px 48px;
+  }
+
+  .blog-author-image {
+    margin-bottom: 52px;
+  }
+
+  .blog-author-image picture {
+    width: 328px;
+  }
+
+  .blog-author-image img {
+    width: 328px;
+    height: 328px;
+    aspect-ratio: auto;
+  }
+
+  /* Full-width variant: image fills content area width */
+  .blog-author.full-width .blog-author-image picture {
+    width: 100%;
+  }
+
+  .blog-author.full-width .blog-author-image img {
+    width: 100%;
+    height: 328px;
+  }
+}
+
+/* Desktop 1200px+: 2-column grid, 328x328 image left, content right */
+@media (min-width: 1200px) {
+  .blog-author {
     display: grid;
-    grid-template-columns: 120px 1fr;
-    column-gap: 24px;
-    row-gap: 0;
+    grid-template-columns: 328px minmax(0, 600px);
+    column-gap: 32px;
     align-items: start;
-    padding: 56px 30px;
+    justify-content: center;
   }
 
   .blog-author-image {
@@ -122,41 +183,17 @@
   }
 
   .blog-author-image picture {
-    width: 120px;
+    width: 328px;
   }
 
   .blog-author-image img {
-    border-radius: 50%;
-    width: 120px;
-    height: 120px;
-    aspect-ratio: auto;
+    width: 328px;
+    height: 328px;
   }
 
   .blog-author-info,
   .blog-author-social,
   .blog-author-subscribe {
     grid-column: 2;
-  }
-
-  .blog-author-social {
-    gap: 16px;
-    margin-top: 16px;
-  }
-}
-
-/* Desktop 1200px+: larger image */
-@media (min-width: 1200px) {
-  .blog-author {
-    grid-template-columns: 160px 1fr;
-    column-gap: 32px;
-  }
-
-  .blog-author-image picture {
-    width: 160px;
-  }
-
-  .blog-author-image img {
-    width: 160px;
-    height: 160px;
   }
 }

--- a/blog/blocks/blog-author/blog-author.css
+++ b/blog/blocks/blog-author/blog-author.css
@@ -52,7 +52,7 @@
 .blog-author-social {
   display: flex;
   flex-wrap: wrap;
-  gap: 16px;
+  gap: 8px;
   align-items: center;
   margin-top: 32px;
 }
@@ -61,15 +61,22 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
-  height: 32px;
-  color: inherit;
+  width: 40px;
+  height: 40px;
+  background: var(--color-gray-700, #2c2c2c);
+  border-radius: 8px;
+  color: #fff;
   text-decoration: none;
 }
 
 .blog-author-social .icon {
-  width: 32px;
-  height: 32px;
+  display: contents;
+}
+
+.blog-author-social .icon svg {
+  display: block;
+  width: 22px;
+  height: 22px;
 }
 
 .blog-author-subscribe {
@@ -132,6 +139,7 @@
   }
 
   .blog-author-social {
+    gap: 16px;
     margin-top: 16px;
   }
 }

--- a/blog/blocks/blog-author/blog-author.css
+++ b/blog/blocks/blog-author/blog-author.css
@@ -20,11 +20,6 @@
   object-position: top center;
 }
 
-.blog-author-info {
-  display: flex;
-  flex-direction: column;
-}
-
 .blog-author-name {
   font-size: 36px;
   font-weight: 700;
@@ -185,7 +180,9 @@
     object-position: top center;
   }
 
-  .blog-author-info,
+  .blog-author-name,
+  .blog-author-title,
+  .blog-author-description,
   .blog-author-social,
   .blog-author-subscribe {
     grid-column: 2;

--- a/blog/blocks/blog-author/blog-author.css
+++ b/blog/blocks/blog-author/blog-author.css
@@ -1,9 +1,7 @@
-/* Outer row wrappers are transparent to layout */
 .blog-author > div {
   display: contents;
 }
 
-/* Mobile 360-599px */
 .blog-author {
   display: flex;
   flex-direction: column;
@@ -104,7 +102,6 @@
   color: inherit;
 }
 
-/* Small tablet 600-767px: stacked, 300x300 image */
 @media (min-width: 600px) {
   .blog-author {
     padding: 56px 32px;
@@ -120,7 +117,6 @@
     aspect-ratio: auto;
   }
 
-  /* Full-width variant: image fills content area width */
   .blog-author.full-width .blog-author-image picture {
     width: 100%;
   }
@@ -135,7 +131,6 @@
   }
 }
 
-/* Tablet 768-1199px: stacked, 328x328 image, 48px side padding */
 @media (min-width: 768px) {
   .blog-author {
     padding: 56px 48px;
@@ -155,7 +150,6 @@
     aspect-ratio: auto;
   }
 
-  /* Full-width variant: image fills content area width */
   .blog-author.full-width .blog-author-image picture {
     width: 100%;
   }
@@ -166,7 +160,6 @@
   }
 }
 
-/* Desktop 1200px+: 2-column grid, 328x328 image left, content right */
 @media (min-width: 1200px) {
   .blog-author {
     display: grid;

--- a/blog/blocks/blog-author/blog-author.css
+++ b/blog/blocks/blog-author/blog-author.css
@@ -12,10 +12,6 @@
   margin-bottom: 48px;
 }
 
-.blog-author-image picture {
-  display: block;
-}
-
 .blog-author-image img {
   display: block;
   width: 100%;
@@ -113,7 +109,6 @@
 
   .blog-author-image img {
     width: 300px;
-    height: 300px;
     aspect-ratio: auto;
   }
 
@@ -146,7 +141,6 @@
 
   .blog-author-image img {
     width: 328px;
-    height: 328px;
     aspect-ratio: auto;
   }
 

--- a/blog/blocks/blog-author/blog-author.css
+++ b/blog/blocks/blog-author/blog-author.css
@@ -1,0 +1,69 @@
+.blog-author {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 24px 0;
+}
+
+.blog-author-image picture {
+  display: block;
+}
+
+.blog-author-image img {
+  border-radius: 50%;
+  width: 80px;
+  height: 80px;
+  object-fit: cover;
+}
+
+.blog-author-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.blog-author-name {
+  font-weight: bold;
+  margin: 0;
+}
+
+.blog-author-title {
+  color: var(--color-gray-500, #6e6e6e);
+  margin: 0;
+}
+
+.blog-author-description {
+  margin: 8px 0 0;
+}
+
+.blog-author-social {
+  display: flex;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.blog-author-social a {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+}
+
+.blog-author-social .icon {
+  width: 20px;
+  height: 20px;
+}
+
+@media (min-width: 768px) {
+  .blog-author {
+    flex-direction: row;
+    align-items: flex-start;
+    gap: 24px;
+  }
+
+  .blog-author-image img {
+    width: 120px;
+    height: 120px;
+  }
+}

--- a/blog/blocks/blog-author/blog-author.css
+++ b/blog/blocks/blog-author/blog-author.css
@@ -164,6 +164,7 @@
   .blog-author {
     display: grid;
     grid-template-columns: 328px minmax(0, 600px);
+    grid-template-rows: repeat(5, auto);
     column-gap: 32px;
     align-items: start;
     justify-content: center;
@@ -172,16 +173,22 @@
   .blog-author-image {
     grid-column: 1;
     grid-row: 1 / -1;
+    align-self: stretch;
+    display: flex;
+    flex-direction: column;
     margin-bottom: 0;
   }
 
   .blog-author-image picture {
-    width: 328px;
+    display: contents;
   }
 
   .blog-author-image img {
     width: 328px;
-    height: 328px;
+    flex: 1;
+    min-height: 328px;
+    object-fit: cover;
+    object-position: top center;
   }
 
   .blog-author-info,

--- a/blog/blocks/blog-author/blog-author.css
+++ b/blog/blocks/blog-author/blog-author.css
@@ -1,8 +1,17 @@
+/* Outer row wrappers are transparent to layout */
+.blog-author > div {
+  display: contents;
+}
+
+/* Mobile 360-599px */
 .blog-author {
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  padding: 24px 0;
+  padding: 56px 30px;
+}
+
+.blog-author-image {
+  margin-bottom: 48px;
 }
 
 .blog-author-image picture {
@@ -10,36 +19,42 @@
 }
 
 .blog-author-image img {
-  border-radius: 50%;
-  width: 80px;
-  height: 80px;
+  display: block;
+  width: 100%;
+  aspect-ratio: 1;
   object-fit: cover;
+  object-position: top center;
 }
 
 .blog-author-info {
   display: flex;
   flex-direction: column;
-  gap: 4px;
 }
 
 .blog-author-name {
-  font-weight: bold;
-  margin: 0;
+  font-size: 36px;
+  font-weight: 700;
+  line-height: 1.2;
+  margin: 0 0 8px;
 }
 
 .blog-author-title {
-  color: var(--color-gray-500, #6e6e6e);
-  margin: 0;
+  font-size: 20px;
+  font-weight: 700;
+  margin: 0 0 8px;
 }
 
 .blog-author-description {
-  margin: 8px 0 0;
+  font-size: 20px;
+  margin: 0;
 }
 
 .blog-author-social {
   display: flex;
-  gap: 12px;
-  margin-top: 8px;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+  margin-top: 32px;
 }
 
 .blog-author-social a {
@@ -48,22 +63,92 @@
   justify-content: center;
   width: 32px;
   height: 32px;
+  color: inherit;
+  text-decoration: none;
 }
 
 .blog-author-social .icon {
-  width: 20px;
-  height: 20px;
+  width: 32px;
+  height: 32px;
 }
 
-@media (min-width: 768px) {
+.blog-author-subscribe {
+  background: var(--color-gray-100, #f5f5f5);
+  border-radius: 8px;
+  padding: 16px;
+  margin-top: 16px;
+}
+
+.blog-author-subscribe p {
+  font-size: 18px;
+  font-weight: 700;
+  margin: 0 0 16px;
+}
+
+.blog-author-subscribe-btn {
+  display: inline-block;
+  border: 2px solid var(--color-gray-700, #2c2c2c);
+  border-radius: 20px;
+  padding: 6px 20px;
+  font-size: 15px;
+  font-weight: 600;
+  text-decoration: none;
+  text-transform: capitalize;
+  color: inherit;
+}
+
+/* Tablet 600px+: image becomes circle on left, content stacks on right */
+@media (min-width: 600px) {
   .blog-author {
-    flex-direction: row;
-    align-items: flex-start;
-    gap: 24px;
+    display: grid;
+    grid-template-columns: 120px 1fr;
+    column-gap: 24px;
+    row-gap: 0;
+    align-items: start;
+    padding: 56px 30px;
+  }
+
+  .blog-author-image {
+    grid-column: 1;
+    grid-row: 1 / -1;
+    margin-bottom: 0;
+  }
+
+  .blog-author-image picture {
+    width: 120px;
   }
 
   .blog-author-image img {
+    border-radius: 50%;
     width: 120px;
     height: 120px;
+    aspect-ratio: auto;
+  }
+
+  .blog-author-info,
+  .blog-author-social,
+  .blog-author-subscribe {
+    grid-column: 2;
+  }
+
+  .blog-author-social {
+    margin-top: 16px;
+  }
+}
+
+/* Desktop 1200px+: larger image */
+@media (min-width: 1200px) {
+  .blog-author {
+    grid-template-columns: 160px 1fr;
+    column-gap: 32px;
+  }
+
+  .blog-author-image picture {
+    width: 160px;
+  }
+
+  .blog-author-image img {
+    width: 160px;
+    height: 160px;
   }
 }

--- a/blog/blocks/blog-author/blog-author.js
+++ b/blog/blocks/blog-author/blog-author.js
@@ -1,5 +1,7 @@
 import { LIBS } from '../../scripts/scripts.js';
 
+const { getConfig } = await import(`${LIBS}/utils/utils.js`);
+const { replaceKey } = await import(`${LIBS}/features/placeholders.js`);
 const iconsModule = await import(`${LIBS}/features/icons/icons.js`).catch(() => null);
 const loadIcons = iconsModule?.default ?? (() => {});
 
@@ -16,8 +18,11 @@ function resolvePlatform(href) {
 }
 
 function decorateSocial(row) {
+  // Links may be wrapped in <p> tags — flatten them to direct children
+  const links = [...row.querySelectorAll('a')];
+  row.replaceChildren(...links);
   row.className = 'blog-author-social';
-  row.querySelectorAll('a').forEach((a) => {
+  links.forEach((a) => {
     const domain = resolvePlatform(a.href);
     if (!domain) { a.hidden = true; return; }
     const { name, icon } = SOCIAL_PLATFORMS[domain];
@@ -31,15 +36,55 @@ function decorateSocial(row) {
   loadIcons(row.querySelectorAll('span.icon'));
 }
 
-// Expects each field (name, title, description) as a separate <p> in the authored doc.
+function normalizeBrToParagraphs(row) {
+  const nodes = [...row.childNodes];
+  const paras = [];
+  let p = document.createElement('p');
+  nodes.forEach((node) => {
+    if (node.nodeName === 'BR') {
+      if (p.textContent.trim()) paras.push(p);
+      p = document.createElement('p');
+    } else {
+      p.append(node.cloneNode(true));
+    }
+  });
+  if (p.textContent.trim()) paras.push(p);
+  row.replaceChildren(...paras);
+}
+
 function decorateText(row) {
   row.className = 'blog-author-info';
+  if (!row.querySelector('p') && row.querySelector('br')) normalizeBrToParagraphs(row);
   const paras = row.querySelectorAll('p');
   if (paras[0]) paras[0].className = 'blog-author-name';
   if (paras[1]) paras[1].className = 'blog-author-title';
   paras.forEach((p, i) => {
     if (i >= 2) p.className = 'blog-author-description';
   });
+}
+
+async function decorateSubscribe(row) {
+  row.className = 'blog-author-subscribe';
+  const cfg = getConfig();
+  const resolve = async (key) => {
+    const val = await replaceKey(key, cfg).catch(() => '');
+    return val && val.toLowerCase().replace(/[\s-]+/g, '-') !== key ? val : '';
+  };
+  const body = await resolve('get-the-latest-articles') || 'Get the latest articles sent to your inbox.';
+  const btn = await resolve('subscribe') || 'Subscribe';
+
+  const a = row.querySelector('a');
+  row.replaceChildren();
+
+  const p = document.createElement('p');
+  p.textContent = body;
+  row.append(p);
+
+  if (a) {
+    a.textContent = btn;
+    a.className = 'blog-author-subscribe-btn';
+    row.append(a);
+  }
 }
 
 function injectSchema(el) {
@@ -64,8 +109,8 @@ function injectSchema(el) {
   const img = el.querySelector('picture img')?.src;
   if (img) schema.image = img;
 
-  const sameAs = [...el.querySelectorAll('.blog-author-social a')]
-    .map((a) => a.href).filter(Boolean);
+  const sameAs = [...el.querySelectorAll('.blog-author-social a:not([hidden])')]
+    .map((a) => a.getAttribute('aria-label') && a.href).filter(Boolean);
   if (sameAs.length) schema.sameAs = sameAs;
 
   const script = document.createElement('script');
@@ -74,17 +119,32 @@ function injectSchema(el) {
   document.head.append(script);
 }
 
-export default function init(el) {
+export default async function init(el) {
+  let socialContainer = null;
+  const rowsToRemove = [];
+  const subscribeDecorations = [];
+
   [...el.children].forEach((row) => {
     const inner = row.querySelector(':scope > div') ?? row;
     if (inner.querySelector('picture')) {
       inner.className = 'blog-author-image';
     } else if ([...inner.querySelectorAll('a')].some((a) => resolvePlatform(a.href))) {
-      decorateSocial(inner);
+      if (!socialContainer) {
+        socialContainer = inner;
+      } else {
+        [...inner.querySelectorAll('a')].forEach((a) => socialContainer.append(a));
+        rowsToRemove.push(row);
+      }
+    } else if (inner.querySelector('a')) {
+      subscribeDecorations.push(decorateSubscribe(inner));
     } else {
       decorateText(inner);
     }
   });
 
+  if (socialContainer) decorateSocial(socialContainer);
+  rowsToRemove.forEach((r) => r.remove());
+
+  await Promise.all(subscribeDecorations);
   injectSchema(el);
 }

--- a/blog/blocks/blog-author/blog-author.js
+++ b/blog/blocks/blog-author/blog-author.js
@@ -36,25 +36,8 @@ function decorateSocial(row) {
   loadIcons(row.querySelectorAll('span.icon'));
 }
 
-function normalizeBrToParagraphs(row) {
-  const nodes = [...row.childNodes];
-  const paras = [];
-  let p = document.createElement('p');
-  nodes.forEach((node) => {
-    if (node.nodeName === 'BR') {
-      if (p.textContent.trim()) paras.push(p);
-      p = document.createElement('p');
-    } else {
-      p.append(node.cloneNode(true));
-    }
-  });
-  if (p.textContent.trim()) paras.push(p);
-  row.replaceChildren(...paras);
-}
-
 function decorateText(row) {
   row.className = 'blog-author-info';
-  if (!row.querySelector('p') && row.querySelector('br')) normalizeBrToParagraphs(row);
   const paras = row.querySelectorAll('p');
   if (paras[0]) paras[0].className = 'blog-author-name';
   if (paras[1]) paras[1].className = 'blog-author-title';

--- a/blog/blocks/blog-author/blog-author.js
+++ b/blog/blocks/blog-author/blog-author.js
@@ -33,7 +33,7 @@ function decorateSocial(row) {
   loadIcons(row.querySelectorAll('span.icon'));
 }
 
-function injectSchema(el) {
+function injectSchema(el, company) {
   const name = el.querySelector('.blog-author-name')?.textContent;
   if (!name) return;
 
@@ -42,12 +42,11 @@ function injectSchema(el) {
     '@type': 'Person',
     name,
     url: window.location.href,
-    worksFor: {
-      '@type': 'Organization',
-      name: 'Adobe',
-      url: 'https://www.adobe.com/',
-    },
   };
+
+  if (company) {
+    schema.worksFor = { '@type': 'Organization', name: company };
+  }
 
   const title = el.querySelector('.blog-author-title')?.textContent;
   if (title) schema.jobTitle = title;
@@ -72,6 +71,7 @@ function injectSchema(el) {
 export default async function init(el) {
   let socialContainer = null;
   let textIdx = 0;
+  let company = null;
   const TEXT_CLASSES = ['blog-author-name', 'blog-author-title', 'blog-author-description'];
 
   el.querySelectorAll(':scope > div > div').forEach((row) => {
@@ -84,6 +84,9 @@ export default async function init(el) {
         [...row.querySelectorAll('a')].forEach((a) => socialContainer.append(a));
         row.parentElement.remove();
       }
+    } else if (socialContainer) {
+      company = row.textContent.trim();
+      row.parentElement.remove();
     } else {
       row.className = TEXT_CLASSES[Math.min(textIdx, 2)];
       textIdx += 1;
@@ -92,5 +95,5 @@ export default async function init(el) {
 
   if (socialContainer) decorateSocial(socialContainer);
 
-  injectSchema(el);
+  injectSchema(el, company);
 }

--- a/blog/blocks/blog-author/blog-author.js
+++ b/blog/blocks/blog-author/blog-author.js
@@ -77,7 +77,11 @@ function injectSchema(el) {
     '@type': 'Person',
     name,
     url: window.location.href,
-    worksFor: { '@type': 'Organization', name: 'Adobe', url: 'https://www.adobe.com/' }, // TODO: support author-company row when porting to Milo
+    worksFor: {
+      '@type': 'Organization',
+      name: 'Adobe',
+      url: 'https://www.adobe.com/',
+    },
   };
 
   const title = el.querySelector('.blog-author-title')?.textContent?.trim();

--- a/blog/blocks/blog-author/blog-author.js
+++ b/blog/blocks/blog-author/blog-author.js
@@ -1,0 +1,90 @@
+import { LIBS } from '../../scripts/scripts.js';
+
+const iconsModule = await import(`${LIBS}/features/icons/icons.js`).catch(() => null);
+const loadIcons = iconsModule?.default ?? (() => {});
+
+const SOCIAL_PLATFORMS = {
+  'linkedin.com': { name: 'LinkedIn', icon: 'linkedin' },
+  'twitter.com': { name: 'X', icon: 'twitter' },
+  'x.com': { name: 'X', icon: 'twitter' },
+  'facebook.com': { name: 'Facebook', icon: 'facebook' },
+  'instagram.com': { name: 'Instagram', icon: 'instagram' },
+};
+
+function resolvePlatform(href) {
+  return Object.keys(SOCIAL_PLATFORMS).find((domain) => href?.includes(domain));
+}
+
+function decorateSocial(row) {
+  row.className = 'blog-author-social';
+  row.querySelectorAll('a').forEach((a) => {
+    const domain = resolvePlatform(a.href);
+    if (!domain) { a.hidden = true; return; }
+    const { name, icon } = SOCIAL_PLATFORMS[domain];
+    a.setAttribute('aria-label', name);
+    a.target = '_blank';
+    a.rel = 'noopener noreferrer';
+    const span = document.createElement('span');
+    span.className = `icon icon-${icon}`;
+    a.replaceChildren(span);
+  });
+  loadIcons(row.querySelectorAll('span.icon'));
+}
+
+// Expects each field (name, title, description) as a separate <p> in the authored doc.
+function decorateText(row) {
+  row.className = 'blog-author-info';
+  const paras = row.querySelectorAll('p');
+  if (paras[0]) paras[0].className = 'blog-author-name';
+  if (paras[1]) paras[1].className = 'blog-author-title';
+  paras.forEach((p, i) => {
+    if (i >= 2) p.className = 'blog-author-description';
+  });
+}
+
+function injectSchema(el) {
+  const name = el.querySelector('.blog-author-name')?.textContent?.trim();
+  if (!name) return;
+
+  const schema = {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    name,
+    url: window.location.href,
+    worksFor: { '@type': 'Organization', name: 'Adobe', url: 'https://www.adobe.com/' }, // TODO: support author-company row when porting to Milo
+  };
+
+  const title = el.querySelector('.blog-author-title')?.textContent?.trim();
+  if (title) schema.jobTitle = title;
+
+  const desc = [...el.querySelectorAll('.blog-author-description')]
+    .map((p) => p.textContent.trim()).join(' ');
+  if (desc) schema.description = desc;
+
+  const img = el.querySelector('picture img')?.src;
+  if (img) schema.image = img;
+
+  const sameAs = [...el.querySelectorAll('.blog-author-social a')]
+    .map((a) => a.href).filter(Boolean);
+  if (sameAs.length) schema.sameAs = sameAs;
+
+  const script = document.createElement('script');
+  script.type = 'application/ld+json';
+  script.textContent = JSON.stringify(schema);
+  document.head.append(script);
+}
+
+export default function init(el) {
+  [...el.children].forEach((row) => {
+    const inner = row.querySelector(':scope > div') ?? row;
+    if (inner.querySelector('picture')) {
+      inner.className = 'blog-author-image';
+    } else if ([...inner.querySelectorAll('a')].some((a) => resolvePlatform(a.href))) {
+      decorateSocial(inner);
+    } else {
+      decorateText(inner);
+    }
+  });
+
+  injectSchema(el);
+}

--- a/blog/blocks/blog-author/blog-author.js
+++ b/blog/blocks/blog-author/blog-author.js
@@ -1,7 +1,5 @@
 import { LIBS } from '../../scripts/scripts.js';
 
-const { getConfig } = await import(`${LIBS}/utils/utils.js`);
-const { replaceKey } = await import(`${LIBS}/features/placeholders.js`);
 const iconsModule = await import(`${LIBS}/features/icons/icons.js`).catch(() => null);
 const loadIcons = iconsModule?.default ?? (() => {});
 
@@ -33,28 +31,6 @@ function decorateSocial(row) {
     a.replaceChildren(span);
   });
   loadIcons(row.querySelectorAll('span.icon'));
-}
-
-async function decorateSubscribe(row) {
-  row.className = 'blog-author-subscribe';
-  const cfg = getConfig();
-  const resolve = async (key) => {
-    const val = await replaceKey(key, cfg).catch(() => '');
-    return val && val.toLowerCase().replace(/[\s-]+/g, '-') !== key ? val : '';
-  };
-  const body = await resolve('get-the-latest-articles') || 'Get the latest articles sent to your inbox.';
-  const btn = await resolve('subscribe') || 'Subscribe';
-
-  const a = row.querySelector('a');
-  const p = row.querySelector('p') ?? document.createElement('p');
-
-  p.textContent = body;
-  if (a) {
-    a.textContent = btn;
-    a.className = 'blog-author-subscribe-btn';
-  }
-
-  row.replaceChildren(...[p, a].filter(Boolean));
 }
 
 function injectSchema(el) {
@@ -96,7 +72,6 @@ function injectSchema(el) {
 export default async function init(el) {
   let socialContainer = null;
   let textIdx = 0;
-  const subscribeDecorations = [];
   const TEXT_CLASSES = ['blog-author-name', 'blog-author-title', 'blog-author-description'];
 
   el.querySelectorAll(':scope > div > div').forEach((row) => {
@@ -109,8 +84,6 @@ export default async function init(el) {
         [...row.querySelectorAll('a')].forEach((a) => socialContainer.append(a));
         row.parentElement.remove();
       }
-    } else if (row.querySelector('a')) {
-      subscribeDecorations.push(decorateSubscribe(row));
     } else {
       row.className = TEXT_CLASSES[Math.min(textIdx, 2)];
       textIdx += 1;
@@ -119,6 +92,5 @@ export default async function init(el) {
 
   if (socialContainer) decorateSocial(socialContainer);
 
-  await Promise.all(subscribeDecorations);
   injectSchema(el);
 }

--- a/blog/blocks/blog-author/blog-author.js
+++ b/blog/blocks/blog-author/blog-author.js
@@ -35,8 +35,25 @@ function decorateSocial(row) {
   loadIcons(row.querySelectorAll('span.icon'));
 }
 
+function normalizeBrToParagraphs(row) {
+  const nodes = [...row.childNodes];
+  const paras = [];
+  let p = document.createElement('p');
+  nodes.forEach((node) => {
+    if (node.nodeName === 'BR') {
+      if (p.textContent.trim()) paras.push(p);
+      p = document.createElement('p');
+    } else {
+      p.append(node.cloneNode(true));
+    }
+  });
+  if (p.textContent.trim()) paras.push(p);
+  row.replaceChildren(...paras);
+}
+
 function decorateText(row) {
   row.className = 'blog-author-info';
+  if (!row.querySelector('p') && row.querySelector('br')) normalizeBrToParagraphs(row);
   const paras = row.querySelectorAll('p');
   if (paras[0]) paras[0].className = 'blog-author-name';
   if (paras[1]) paras[1].className = 'blog-author-title';
@@ -56,9 +73,9 @@ async function decorateSubscribe(row) {
   const btn = await resolve('subscribe') || 'Subscribe';
 
   const a = row.querySelector('a');
-  const p = row.querySelector('p');
+  const p = row.querySelector('p') ?? document.createElement('p');
 
-  if (p) p.textContent = body;
+  p.textContent = body;
   if (a) {
     a.textContent = btn;
     a.className = 'blog-author-subscribe-btn';

--- a/blog/blocks/blog-author/blog-author.js
+++ b/blog/blocks/blog-author/blog-author.js
@@ -35,33 +35,6 @@ function decorateSocial(row) {
   loadIcons(row.querySelectorAll('span.icon'));
 }
 
-function normalizeBrToParagraphs(row) {
-  const nodes = [...row.childNodes];
-  const paras = [];
-  let p = document.createElement('p');
-  nodes.forEach((node) => {
-    if (node.nodeName === 'BR') {
-      if (p.textContent.trim()) paras.push(p);
-      p = document.createElement('p');
-    } else {
-      p.append(node.cloneNode(true));
-    }
-  });
-  if (p.textContent.trim()) paras.push(p);
-  row.replaceChildren(...paras);
-}
-
-function decorateText(row) {
-  row.className = 'blog-author-info';
-  if (!row.querySelector('p') && row.querySelector('br')) normalizeBrToParagraphs(row);
-  const paras = row.querySelectorAll('p');
-  if (paras[0]) paras[0].className = 'blog-author-name';
-  if (paras[1]) paras[1].className = 'blog-author-title';
-  paras.forEach((p, i) => {
-    if (i >= 2) p.className = 'blog-author-description';
-  });
-}
-
 async function decorateSubscribe(row) {
   row.className = 'blog-author-subscribe';
   const cfg = getConfig();
@@ -85,7 +58,7 @@ async function decorateSubscribe(row) {
 }
 
 function injectSchema(el) {
-  const name = el.querySelector('.blog-author-name')?.textContent?.trim();
+  const name = el.querySelector('.blog-author-name')?.textContent;
   if (!name) return;
 
   const schema = {
@@ -100,11 +73,11 @@ function injectSchema(el) {
     },
   };
 
-  const title = el.querySelector('.blog-author-title')?.textContent?.trim();
+  const title = el.querySelector('.blog-author-title')?.textContent;
   if (title) schema.jobTitle = title;
 
   const desc = [...el.querySelectorAll('.blog-author-description')]
-    .map((p) => p.textContent.trim()).join(' ');
+    .map((p) => p.textContent).join(' ');
   if (desc) schema.description = desc;
 
   const img = el.querySelector('picture img')?.src;
@@ -122,7 +95,9 @@ function injectSchema(el) {
 
 export default async function init(el) {
   let socialContainer = null;
+  let textIdx = 0;
   const subscribeDecorations = [];
+  const TEXT_CLASSES = ['blog-author-name', 'blog-author-title', 'blog-author-description'];
 
   el.querySelectorAll(':scope > div > div').forEach((row) => {
     if (row.querySelector('picture')) {
@@ -137,7 +112,8 @@ export default async function init(el) {
     } else if (row.querySelector('a')) {
       subscribeDecorations.push(decorateSubscribe(row));
     } else {
-      decorateText(row);
+      row.className = TEXT_CLASSES[Math.min(textIdx, 2)];
+      textIdx += 1;
     }
   });
 

--- a/blog/blocks/blog-author/blog-author.js
+++ b/blog/blocks/blog-author/blog-author.js
@@ -122,29 +122,26 @@ function injectSchema(el) {
 
 export default async function init(el) {
   let socialContainer = null;
-  const rowsToRemove = [];
   const subscribeDecorations = [];
 
-  [...el.children].forEach((row) => {
-    const inner = row.querySelector(':scope > div') ?? row;
-    if (inner.querySelector('picture')) {
-      inner.className = 'blog-author-image';
-    } else if ([...inner.querySelectorAll('a')].some((a) => resolvePlatform(a.href))) {
+  el.querySelectorAll(':scope > div > div').forEach((row) => {
+    if (row.querySelector('picture')) {
+      row.className = 'blog-author-image';
+    } else if ([...row.querySelectorAll('a')].some((a) => resolvePlatform(a.href))) {
       if (!socialContainer) {
-        socialContainer = inner;
+        socialContainer = row;
       } else {
-        [...inner.querySelectorAll('a')].forEach((a) => socialContainer.append(a));
-        rowsToRemove.push(row);
+        [...row.querySelectorAll('a')].forEach((a) => socialContainer.append(a));
+        row.parentElement.remove();
       }
-    } else if (inner.querySelector('a')) {
-      subscribeDecorations.push(decorateSubscribe(inner));
+    } else if (row.querySelector('a')) {
+      subscribeDecorations.push(decorateSubscribe(row));
     } else {
-      decorateText(inner);
+      decorateText(row);
     }
   });
 
   if (socialContainer) decorateSocial(socialContainer);
-  rowsToRemove.forEach((r) => r.remove());
 
   await Promise.all(subscribeDecorations);
   injectSchema(el);

--- a/blog/blocks/blog-author/blog-author.js
+++ b/blog/blocks/blog-author/blog-author.js
@@ -18,7 +18,6 @@ function resolvePlatform(href) {
 }
 
 function decorateSocial(row) {
-  // Links may be wrapped in <p> tags — flatten them to direct children
   const links = [...row.querySelectorAll('a')];
   row.replaceChildren(...links);
   row.className = 'blog-author-social';

--- a/blog/blocks/blog-author/blog-author.js
+++ b/blog/blocks/blog-author/blog-author.js
@@ -57,17 +57,15 @@ async function decorateSubscribe(row) {
   const btn = await resolve('subscribe') || 'Subscribe';
 
   const a = row.querySelector('a');
-  row.replaceChildren();
+  const p = row.querySelector('p');
 
-  const p = document.createElement('p');
-  p.textContent = body;
-  row.append(p);
-
+  if (p) p.textContent = body;
   if (a) {
     a.textContent = btn;
     a.className = 'blog-author-subscribe-btn';
-    row.append(a);
   }
+
+  row.replaceChildren(...[p, a].filter(Boolean));
 }
 
 function injectSchema(el) {

--- a/test/blocks/blog-author/blog-author.test.js
+++ b/test/blocks/blog-author/blog-author.test.js
@@ -13,6 +13,9 @@ const BLOCK_HTML = `
     <a href="https://linkedin.com/in/janedoe">LinkedIn</a>
     <a href="https://twitter.com/janedoe">Twitter</a>
   </div></div>
+  <div><div>
+    <a href="https://example.com/subscribe">Subscribe</a>
+  </div></div>
 </div>`;
 
 function getPersonSchema() {
@@ -32,56 +35,64 @@ describe('Blog Author', () => {
     document.head.querySelectorAll('script[type="application/ld+json"]').forEach((s) => s.remove());
   });
 
-  it('adds class to image row', () => {
-    init(document.querySelector('.blog-author'));
+  it('adds class to image row', async () => {
+    await init(document.querySelector('.blog-author'));
     expect(document.querySelector('.blog-author-image')).to.exist;
     expect(document.querySelector('.blog-author-image picture')).to.exist;
   });
 
-  it('adds name and title classes to text paragraphs', () => {
-    init(document.querySelector('.blog-author'));
+  it('adds name and title classes to text paragraphs', async () => {
+    await init(document.querySelector('.blog-author'));
     expect(document.querySelector('.blog-author-name').textContent).to.equal('Jane Doe');
     expect(document.querySelector('.blog-author-title').textContent).to.equal('Senior Director, Marketing');
   });
 
-  it('adds description class to remaining paragraphs', () => {
-    init(document.querySelector('.blog-author'));
+  it('adds description class to remaining paragraphs', async () => {
+    await init(document.querySelector('.blog-author'));
     expect(document.querySelector('.blog-author-description').textContent).to.include('15 years');
   });
 
-  it('adds blog-author-info class to text row', () => {
-    init(document.querySelector('.blog-author'));
+  it('adds blog-author-info class to text row', async () => {
+    await init(document.querySelector('.blog-author'));
     expect(document.querySelector('.blog-author-info')).to.exist;
   });
 
-  it('adds blog-author-social class to links row', () => {
-    init(document.querySelector('.blog-author'));
+  it('adds blog-author-social class to links row', async () => {
+    await init(document.querySelector('.blog-author'));
     expect(document.querySelector('.blog-author-social')).to.exist;
   });
 
-  it('adds aria-labels to known social links', () => {
-    init(document.querySelector('.blog-author'));
+  it('adds aria-labels to known social links', async () => {
+    await init(document.querySelector('.blog-author'));
     const links = document.querySelectorAll('.blog-author-social a');
     expect(links[0].getAttribute('aria-label')).to.equal('LinkedIn');
     expect(links[1].getAttribute('aria-label')).to.equal('X');
   });
 
-  it('sets target and rel on social links', () => {
-    init(document.querySelector('.blog-author'));
+  it('sets target and rel on social links', async () => {
+    await init(document.querySelector('.blog-author'));
     const link = document.querySelector('.blog-author-social a');
     expect(link.target).to.equal('_blank');
     expect(link.rel).to.equal('noopener noreferrer');
   });
 
-  it('adds icon spans to social links', () => {
-    init(document.querySelector('.blog-author'));
+  it('adds icon spans to social links', async () => {
+    await init(document.querySelector('.blog-author'));
     const links = document.querySelectorAll('.blog-author-social a');
     expect(links[0].querySelector('.icon-linkedin')).to.exist;
     expect(links[1].querySelector('.icon-twitter')).to.exist;
   });
 
-  it('injects Person JSON-LD schema', () => {
-    init(document.querySelector('.blog-author'));
+  it('decorates subscribe CTA row', async () => {
+    await init(document.querySelector('.blog-author'));
+    const sub = document.querySelector('.blog-author-subscribe');
+    expect(sub).to.exist;
+    expect(sub.querySelector('.blog-author-subscribe-btn')).to.exist;
+    expect(sub.querySelector('.blog-author-subscribe-btn').href).to.include('subscribe');
+  });
+
+  it('injects Person JSON-LD schema', async () => {
+    await init(document.querySelector('.blog-author'));
     const schema = getPersonSchema();
     expect(schema).to.exist;
     expect(schema['@type']).to.equal('Person');
@@ -91,40 +102,59 @@ describe('Blog Author', () => {
     expect(schema.worksFor.name).to.equal('Adobe');
   });
 
-  it('includes image and sameAs in schema', () => {
-    init(document.querySelector('.blog-author'));
+  it('includes image and sameAs in schema', async () => {
+    await init(document.querySelector('.blog-author'));
     const schema = getPersonSchema();
     expect(schema.image).to.include('example.com/author.jpg');
     expect(schema.sameAs).to.include('https://linkedin.com/in/janedoe');
     expect(schema.sameAs).to.include('https://twitter.com/janedoe');
   });
 
-  it('omits schema fields when content is absent', () => {
+  it('omits schema fields when content is absent', async () => {
     document.body.innerHTML = `
       <div class="blog-author">
         <div><div><p>Jane Doe</p></div></div>
       </div>`;
-    init(document.querySelector('.blog-author'));
+    await init(document.querySelector('.blog-author'));
     const schema = getPersonSchema();
     expect(schema.image).to.be.undefined;
     expect(schema.sameAs).to.be.undefined;
     expect(schema.jobTitle).to.be.undefined;
   });
 
-  it('treats a bio row with a non-social link as text, not social', () => {
+  it('merges social links from multiple authored rows into one container', async () => {
+    document.body.innerHTML = `
+      <div class="blog-author">
+        <div><div>
+          <a href="https://linkedin.com/in/jane">LinkedIn</a>
+          <a href="https://instagram.com/jane">Instagram</a>
+        </div></div>
+        <div><div>
+          <a href="https://twitter.com/jane">Twitter</a>
+        </div></div>
+      </div>`;
+    await init(document.querySelector('.blog-author'));
+    const socialContainers = document.querySelectorAll('.blog-author-social');
+    expect(socialContainers).to.have.length(1);
+    expect(socialContainers[0].querySelectorAll('a')).to.have.length(3);
+  });
+
+  it('treats a bio row with a non-social link as subscribe, not social', async () => {
     document.body.innerHTML = `
       <div class="blog-author">
         <div><div>
           <p>Jane Doe</p>
-          <p>Director at <a href="https://example.com">Example Co</a></p>
+        </div></div>
+        <div><div>
+          <a href="https://example.com/subscribe">Subscribe</a>
         </div></div>
       </div>`;
-    init(document.querySelector('.blog-author'));
-    expect(document.querySelector('.blog-author-info')).to.exist;
+    await init(document.querySelector('.blog-author'));
+    expect(document.querySelector('.blog-author-subscribe')).to.exist;
     expect(document.querySelector('.blog-author-social')).to.not.exist;
   });
 
-  it('hides unrecognized links in the social row', () => {
+  it('hides unrecognized links in the social row', async () => {
     document.body.innerHTML = `
       <div class="blog-author">
         <div><div>
@@ -132,15 +162,26 @@ describe('Blog Author', () => {
           <a href="https://example.com/jane">Website</a>
         </div></div>
       </div>`;
-    init(document.querySelector('.blog-author'));
+    await init(document.querySelector('.blog-author'));
     const links = document.querySelectorAll('.blog-author-social a');
     expect(links[0].hidden).to.be.false;
     expect(links[1].hidden).to.be.true;
   });
 
-  it('does not inject schema when name is missing', () => {
+  it('handles <br>-separated text content instead of <p> tags', async () => {
+    document.body.innerHTML = `
+      <div class="blog-author">
+        <div><div>Shelly Chiang<br>Senior Manager, Adobe for Business<br>Shelly is a senior manager.</div></div>
+      </div>`;
+    await init(document.querySelector('.blog-author'));
+    expect(document.querySelector('.blog-author-name').textContent).to.equal('Shelly Chiang');
+    expect(document.querySelector('.blog-author-title').textContent).to.equal('Senior Manager, Adobe for Business');
+    expect(document.querySelector('.blog-author-description').textContent).to.include('senior manager');
+  });
+
+  it('does not inject schema when name is missing', async () => {
     document.body.innerHTML = '<div class="blog-author"><div><div><picture><img src="x.jpg"></picture></div></div></div>';
-    init(document.querySelector('.blog-author'));
+    await init(document.querySelector('.blog-author'));
     expect(getPersonSchema()).to.be.null;
   });
 });

--- a/test/blocks/blog-author/blog-author.test.js
+++ b/test/blocks/blog-author/blog-author.test.js
@@ -1,0 +1,146 @@
+import { expect } from '@esm-bundle/chai';
+import init from '../../../blog/blocks/blog-author/blog-author.js';
+
+const BLOCK_HTML = `
+<div class="blog-author">
+  <div><div><picture><img src="https://example.com/author.jpg" alt="Jane Doe"></picture></div></div>
+  <div><div>
+    <p>Jane Doe</p>
+    <p>Senior Director, Marketing</p>
+    <p>Jane has 15 years of experience in B2B marketing.</p>
+  </div></div>
+  <div><div>
+    <a href="https://linkedin.com/in/janedoe">LinkedIn</a>
+    <a href="https://twitter.com/janedoe">Twitter</a>
+  </div></div>
+</div>`;
+
+function getPersonSchema() {
+  const scripts = [...document.head.querySelectorAll('script[type="application/ld+json"]')];
+  const script = scripts.find((s) => {
+    try { return JSON.parse(s.textContent)['@type'] === 'Person'; } catch { return false; }
+  });
+  return script ? JSON.parse(script.textContent) : null;
+}
+
+describe('Blog Author', () => {
+  beforeEach(() => {
+    document.body.innerHTML = BLOCK_HTML;
+  });
+
+  afterEach(() => {
+    document.head.querySelectorAll('script[type="application/ld+json"]').forEach((s) => s.remove());
+  });
+
+  it('adds class to image row', () => {
+    init(document.querySelector('.blog-author'));
+    expect(document.querySelector('.blog-author-image')).to.exist;
+    expect(document.querySelector('.blog-author-image picture')).to.exist;
+  });
+
+  it('adds name and title classes to text paragraphs', () => {
+    init(document.querySelector('.blog-author'));
+    expect(document.querySelector('.blog-author-name').textContent).to.equal('Jane Doe');
+    expect(document.querySelector('.blog-author-title').textContent).to.equal('Senior Director, Marketing');
+  });
+
+  it('adds description class to remaining paragraphs', () => {
+    init(document.querySelector('.blog-author'));
+    expect(document.querySelector('.blog-author-description').textContent).to.include('15 years');
+  });
+
+  it('adds blog-author-info class to text row', () => {
+    init(document.querySelector('.blog-author'));
+    expect(document.querySelector('.blog-author-info')).to.exist;
+  });
+
+  it('adds blog-author-social class to links row', () => {
+    init(document.querySelector('.blog-author'));
+    expect(document.querySelector('.blog-author-social')).to.exist;
+  });
+
+  it('adds aria-labels to known social links', () => {
+    init(document.querySelector('.blog-author'));
+    const links = document.querySelectorAll('.blog-author-social a');
+    expect(links[0].getAttribute('aria-label')).to.equal('LinkedIn');
+    expect(links[1].getAttribute('aria-label')).to.equal('X');
+  });
+
+  it('sets target and rel on social links', () => {
+    init(document.querySelector('.blog-author'));
+    const link = document.querySelector('.blog-author-social a');
+    expect(link.target).to.equal('_blank');
+    expect(link.rel).to.equal('noopener noreferrer');
+  });
+
+  it('adds icon spans to social links', () => {
+    init(document.querySelector('.blog-author'));
+    const links = document.querySelectorAll('.blog-author-social a');
+    expect(links[0].querySelector('.icon-linkedin')).to.exist;
+    expect(links[1].querySelector('.icon-twitter')).to.exist;
+  });
+
+  it('injects Person JSON-LD schema', () => {
+    init(document.querySelector('.blog-author'));
+    const schema = getPersonSchema();
+    expect(schema).to.exist;
+    expect(schema['@type']).to.equal('Person');
+    expect(schema.name).to.equal('Jane Doe');
+    expect(schema.jobTitle).to.equal('Senior Director, Marketing');
+    expect(schema.url).to.be.a('string');
+    expect(schema.worksFor.name).to.equal('Adobe');
+  });
+
+  it('includes image and sameAs in schema', () => {
+    init(document.querySelector('.blog-author'));
+    const schema = getPersonSchema();
+    expect(schema.image).to.include('example.com/author.jpg');
+    expect(schema.sameAs).to.include('https://linkedin.com/in/janedoe');
+    expect(schema.sameAs).to.include('https://twitter.com/janedoe');
+  });
+
+  it('omits schema fields when content is absent', () => {
+    document.body.innerHTML = `
+      <div class="blog-author">
+        <div><div><p>Jane Doe</p></div></div>
+      </div>`;
+    init(document.querySelector('.blog-author'));
+    const schema = getPersonSchema();
+    expect(schema.image).to.be.undefined;
+    expect(schema.sameAs).to.be.undefined;
+    expect(schema.jobTitle).to.be.undefined;
+  });
+
+  it('treats a bio row with a non-social link as text, not social', () => {
+    document.body.innerHTML = `
+      <div class="blog-author">
+        <div><div>
+          <p>Jane Doe</p>
+          <p>Director at <a href="https://example.com">Example Co</a></p>
+        </div></div>
+      </div>`;
+    init(document.querySelector('.blog-author'));
+    expect(document.querySelector('.blog-author-info')).to.exist;
+    expect(document.querySelector('.blog-author-social')).to.not.exist;
+  });
+
+  it('hides unrecognized links in the social row', () => {
+    document.body.innerHTML = `
+      <div class="blog-author">
+        <div><div>
+          <a href="https://linkedin.com/in/jane">LinkedIn</a>
+          <a href="https://example.com/jane">Website</a>
+        </div></div>
+      </div>`;
+    init(document.querySelector('.blog-author'));
+    const links = document.querySelectorAll('.blog-author-social a');
+    expect(links[0].hidden).to.be.false;
+    expect(links[1].hidden).to.be.true;
+  });
+
+  it('does not inject schema when name is missing', () => {
+    document.body.innerHTML = '<div class="blog-author"><div><div><picture><img src="x.jpg"></picture></div></div></div>';
+    init(document.querySelector('.blog-author'));
+    expect(getPersonSchema()).to.be.null;
+  });
+});

--- a/test/blocks/blog-author/blog-author.test.js
+++ b/test/blocks/blog-author/blog-author.test.js
@@ -86,7 +86,7 @@ describe('Blog Author', () => {
     expect(schema.name).to.equal('Jane Doe');
     expect(schema.jobTitle).to.equal('Senior Director, Marketing');
     expect(schema.url).to.be.a('string');
-    expect(schema.worksFor.name).to.equal('Adobe');
+    expect(schema.worksFor).to.be.undefined;
   });
 
   it('includes image and sameAs in schema', async () => {
@@ -95,6 +95,27 @@ describe('Blog Author', () => {
     expect(schema.image).to.include('example.com/author.jpg');
     expect(schema.sameAs).to.include('https://linkedin.com/in/janedoe');
     expect(schema.sameAs).to.include('https://twitter.com/janedoe');
+  });
+
+  it('reads company row after social links into schema and removes it from DOM', async () => {
+    document.body.innerHTML = `
+      <div class="blog-author">
+        <div><div><p>Jane Doe</p></div></div>
+        <div><div>
+          <a href="https://linkedin.com/in/jane">LinkedIn</a>
+        </div></div>
+        <div><div><p>Adobe</p></div></div>
+      </div>`;
+    await init(document.querySelector('.blog-author'));
+    const schema = getPersonSchema();
+    expect(schema.worksFor.name).to.equal('Adobe');
+    expect(document.querySelector('.blog-author').textContent).to.not.include('Adobe');
+  });
+
+  it('omits worksFor from schema when no company row is authored', async () => {
+    await init(document.querySelector('.blog-author'));
+    const schema = getPersonSchema();
+    expect(schema.worksFor).to.be.undefined;
   });
 
   it('omits schema fields when content is absent', async () => {

--- a/test/blocks/blog-author/blog-author.test.js
+++ b/test/blocks/blog-author/blog-author.test.js
@@ -14,7 +14,7 @@ const BLOCK_HTML = `
     <a href="https://twitter.com/janedoe">Twitter</a>
   </div></div>
   <div><div>
-    <a href="https://example.com/subscribe">Subscribe</a>
+    <p><a href="https://example.com/subscribe">Subscribe</a></p>
   </div></div>
 </div>`;
 
@@ -146,7 +146,7 @@ describe('Blog Author', () => {
           <p>Jane Doe</p>
         </div></div>
         <div><div>
-          <a href="https://example.com/subscribe">Subscribe</a>
+          <p><a href="https://example.com/subscribe">Subscribe</a></p>
         </div></div>
       </div>`;
     await init(document.querySelector('.blog-author'));

--- a/test/blocks/blog-author/blog-author.test.js
+++ b/test/blocks/blog-author/blog-author.test.js
@@ -168,6 +168,17 @@ describe('Blog Author', () => {
     expect(links[1].hidden).to.be.true;
   });
 
+  it('handles <br>-separated text content instead of <p> tags', async () => {
+    document.body.innerHTML = `
+      <div class="blog-author">
+        <div><div>Shelly Chiang<br>Senior Manager, Adobe for Business<br>Shelly is a senior manager.</div></div>
+      </div>`;
+    await init(document.querySelector('.blog-author'));
+    expect(document.querySelector('.blog-author-name').textContent).to.equal('Shelly Chiang');
+    expect(document.querySelector('.blog-author-title').textContent).to.equal('Senior Manager, Adobe for Business');
+    expect(document.querySelector('.blog-author-description').textContent).to.include('senior manager');
+  });
+
   it('does not inject schema when name is missing', async () => {
     document.body.innerHTML = '<div class="blog-author"><div><div><picture><img src="x.jpg"></picture></div></div></div>';
     await init(document.querySelector('.blog-author'));

--- a/test/blocks/blog-author/blog-author.test.js
+++ b/test/blocks/blog-author/blog-author.test.js
@@ -168,17 +168,6 @@ describe('Blog Author', () => {
     expect(links[1].hidden).to.be.true;
   });
 
-  it('handles <br>-separated text content instead of <p> tags', async () => {
-    document.body.innerHTML = `
-      <div class="blog-author">
-        <div><div>Shelly Chiang<br>Senior Manager, Adobe for Business<br>Shelly is a senior manager.</div></div>
-      </div>`;
-    await init(document.querySelector('.blog-author'));
-    expect(document.querySelector('.blog-author-name').textContent).to.equal('Shelly Chiang');
-    expect(document.querySelector('.blog-author-title').textContent).to.equal('Senior Manager, Adobe for Business');
-    expect(document.querySelector('.blog-author-description').textContent).to.include('senior manager');
-  });
-
   it('does not inject schema when name is missing', async () => {
     document.body.innerHTML = '<div class="blog-author"><div><div><picture><img src="x.jpg"></picture></div></div></div>';
     await init(document.querySelector('.blog-author'));

--- a/test/blocks/blog-author/blog-author.test.js
+++ b/test/blocks/blog-author/blog-author.test.js
@@ -11,9 +11,6 @@ const BLOCK_HTML = `
     <a href="https://linkedin.com/in/janedoe">LinkedIn</a>
     <a href="https://twitter.com/janedoe">Twitter</a>
   </div></div>
-  <div><div>
-    <p><a href="https://example.com/subscribe">Subscribe</a></p>
-  </div></div>
 </div>`;
 
 function getPersonSchema() {
@@ -81,14 +78,6 @@ describe('Blog Author', () => {
     expect(links[1].querySelector('.icon-twitter')).to.exist;
   });
 
-  it('decorates subscribe CTA row', async () => {
-    await init(document.querySelector('.blog-author'));
-    const sub = document.querySelector('.blog-author-subscribe');
-    expect(sub).to.exist;
-    expect(sub.querySelector('.blog-author-subscribe-btn')).to.exist;
-    expect(sub.querySelector('.blog-author-subscribe-btn').href).to.include('subscribe');
-  });
-
   it('injects Person JSON-LD schema', async () => {
     await init(document.querySelector('.blog-author'));
     const schema = getPersonSchema();
@@ -135,19 +124,6 @@ describe('Blog Author', () => {
     const socialContainers = document.querySelectorAll('.blog-author-social');
     expect(socialContainers).to.have.length(1);
     expect(socialContainers[0].querySelectorAll('a')).to.have.length(3);
-  });
-
-  it('treats a row with a non-social link as subscribe, not social', async () => {
-    document.body.innerHTML = `
-      <div class="blog-author">
-        <div><div><p>Jane Doe</p></div></div>
-        <div><div>
-          <p><a href="https://example.com/subscribe">Subscribe</a></p>
-        </div></div>
-      </div>`;
-    await init(document.querySelector('.blog-author'));
-    expect(document.querySelector('.blog-author-subscribe')).to.exist;
-    expect(document.querySelector('.blog-author-social')).to.not.exist;
   });
 
   it('hides unrecognized links in the social row', async () => {

--- a/test/blocks/blog-author/blog-author.test.js
+++ b/test/blocks/blog-author/blog-author.test.js
@@ -4,11 +4,9 @@ import init from '../../../blog/blocks/blog-author/blog-author.js';
 const BLOCK_HTML = `
 <div class="blog-author">
   <div><div><picture><img src="https://example.com/author.jpg" alt="Jane Doe"></picture></div></div>
-  <div><div>
-    <p>Jane Doe</p>
-    <p>Senior Director, Marketing</p>
-    <p>Jane has 15 years of experience in B2B marketing.</p>
-  </div></div>
+  <div><div><p>Jane Doe</p></div></div>
+  <div><div><p>Senior Director, Marketing</p></div></div>
+  <div><div><p>Jane has 15 years of experience in B2B marketing.</p></div></div>
   <div><div>
     <a href="https://linkedin.com/in/janedoe">LinkedIn</a>
     <a href="https://twitter.com/janedoe">Twitter</a>
@@ -41,20 +39,20 @@ describe('Blog Author', () => {
     expect(document.querySelector('.blog-author-image picture')).to.exist;
   });
 
-  it('adds name and title classes to text paragraphs', async () => {
+  it('assigns name and title classes by row order', async () => {
     await init(document.querySelector('.blog-author'));
     expect(document.querySelector('.blog-author-name').textContent).to.equal('Jane Doe');
     expect(document.querySelector('.blog-author-title').textContent).to.equal('Senior Director, Marketing');
   });
 
-  it('adds description class to remaining paragraphs', async () => {
+  it('assigns description class to third and subsequent text rows', async () => {
     await init(document.querySelector('.blog-author'));
     expect(document.querySelector('.blog-author-description').textContent).to.include('15 years');
   });
 
-  it('adds blog-author-info class to text row', async () => {
+  it('assigns blog-author-name class to the first text row', async () => {
     await init(document.querySelector('.blog-author'));
-    expect(document.querySelector('.blog-author-info')).to.exist;
+    expect(document.querySelector('.blog-author-name')).to.exist;
   });
 
   it('adds blog-author-social class to links row', async () => {
@@ -139,12 +137,10 @@ describe('Blog Author', () => {
     expect(socialContainers[0].querySelectorAll('a')).to.have.length(3);
   });
 
-  it('treats a bio row with a non-social link as subscribe, not social', async () => {
+  it('treats a row with a non-social link as subscribe, not social', async () => {
     document.body.innerHTML = `
       <div class="blog-author">
-        <div><div>
-          <p>Jane Doe</p>
-        </div></div>
+        <div><div><p>Jane Doe</p></div></div>
         <div><div>
           <p><a href="https://example.com/subscribe">Subscribe</a></p>
         </div></div>
@@ -166,17 +162,6 @@ describe('Blog Author', () => {
     const links = document.querySelectorAll('.blog-author-social a');
     expect(links[0].hidden).to.be.false;
     expect(links[1].hidden).to.be.true;
-  });
-
-  it('handles <br>-separated text content instead of <p> tags', async () => {
-    document.body.innerHTML = `
-      <div class="blog-author">
-        <div><div>Shelly Chiang<br>Senior Manager, Adobe for Business<br>Shelly is a senior manager.</div></div>
-      </div>`;
-    await init(document.querySelector('.blog-author'));
-    expect(document.querySelector('.blog-author-name').textContent).to.equal('Shelly Chiang');
-    expect(document.querySelector('.blog-author-title').textContent).to.equal('Senior Manager, Adobe for Business');
-    expect(document.querySelector('.blog-author-description').textContent).to.include('senior manager');
   });
 
   it('does not inject schema when name is missing', async () => {


### PR DESCRIPTION
- Adds `blog-author` block that decorates existing DOM rows (picture, text, social links, subscribe CTA) authored in a DA document
- Injects Person JSON-LD schema from decorated DOM for SEO
- Responsive layout: single-column mobile, two-column grid at 600px+, larger image at 1200px+

Resolves: [MWPW-183849](https://jira.corp.adobe.com/browse/MWPW-183849)

## Test links
Before: https://main--da-bacom-blog--adobecom.aem.live/drafts/jsandlan/blog-author
After: https://blog-author-block--da-bacom-blog--adobecom.aem.live/drafts/jsandlan/blog-author

