### PR TITLE
MWPW-197549 Experience League link transformation

### DIFF
--- a/blog/scripts/scripts.js
+++ b/blog/scripts/scripts.js
@@ -110,40 +110,40 @@ const CONFIG = {
     ae_ar: { ietf: 'ar', tk: 'qxw8hzm.css', dir: 'rtl' },
     ae_en: { ietf: 'en', tk: 'hah7vzn.css' },
     africa: { ietf: 'en', tk: 'hah7vzn.css' },
-    ar: { ietf: 'es-AR', tk: 'hah7vzn.css' },
-    at: { ietf: 'de-AT', tk: 'hah7vzn.css' },
+    ar: { ietf: 'es-AR', tk: 'hah7vzn.css', exl: 'es' },
+    at: { ietf: 'de-AT', tk: 'hah7vzn.css', exl: 'de' },
     au: { ietf: 'en-AU', tk: 'hah7vzn.css' },
     be_en: { ietf: 'en-BE', tk: 'hah7vzn.css' },
-    be_fr: { ietf: 'fr-BE', tk: 'hah7vzn.css' },
-    be_nl: { ietf: 'nl-BE', tk: 'qxw8hzm.css' },
+    be_fr: { ietf: 'fr-BE', tk: 'hah7vzn.css', exl: 'fr' },
+    be_nl: { ietf: 'nl-BE', tk: 'qxw8hzm.css', exl: 'nl' },
     bg: { ietf: 'bg-BG', tk: 'qxw8hzm.css' },
-    br: { ietf: 'pt-BR', tk: 'hah7vzn.css' },
-    ca_fr: { ietf: 'fr-CA', tk: 'hah7vzn.css' },
+    br: { ietf: 'pt-BR', tk: 'hah7vzn.css', exl: 'pt-br' },
+    ca_fr: { ietf: 'fr-CA', tk: 'hah7vzn.css', exl: 'fr' },
     ca: { ietf: 'en-CA', tk: 'hah7vzn.css' },
-    ch_de: { ietf: 'de-CH', tk: 'hah7vzn.css' },
-    ch_fr: { ietf: 'fr-CH', tk: 'hah7vzn.css' },
-    ch_it: { ietf: 'it-CH', tk: 'hah7vzn.css' },
-    cl: { ietf: 'es-CL', tk: 'hah7vzn.css' },
-    cn: { ietf: 'zh-CN', tk: 'qxw8hzm' },
-    co: { ietf: 'es-CO', tk: 'hah7vzn.css' },
+    ch_de: { ietf: 'de-CH', tk: 'hah7vzn.css', exl: 'de' },
+    ch_fr: { ietf: 'fr-CH', tk: 'hah7vzn.css', exl: 'fr' },
+    ch_it: { ietf: 'it-CH', tk: 'hah7vzn.css', exl: 'it' },
+    cl: { ietf: 'es-CL', tk: 'hah7vzn.css', exl: 'es' },
+    cn: { ietf: 'zh-CN', tk: 'qxw8hzm', exl: 'zh-hans' },
+    co: { ietf: 'es-CO', tk: 'hah7vzn.css', exl: 'es' },
     cr: { ietf: 'es-419', tk: 'hah7vzn.css' },
     cy_en: { ietf: 'en-CY', tk: 'hah7vzn.css' },
     cz: { ietf: 'cs-CZ', tk: 'qxw8hzm.css' },
-    de: { ietf: 'de-DE', tk: 'hah7vzn.css' },
+    de: { ietf: 'de-DE', tk: 'hah7vzn.css', exl: 'de' },
     dk: { ietf: 'da-DK', tk: 'qxw8hzm.css' },
     ec: { ietf: 'es-419', tk: 'hah7vzn.css' },
     ee: { ietf: 'et-EE', tk: 'qxw8hzm.css' },
     eg_ar: { ietf: 'ar', tk: 'qxw8hzm.css', dir: 'rtl' },
     eg_en: { ietf: 'en-GB', tk: 'hah7vzn.css' },
     el: { ietf: 'el', tk: 'qxw8hzm.css' },
-    es: { ietf: 'es-ES', tk: 'hah7vzn.css' },
+    es: { ietf: 'es-ES', tk: 'hah7vzn.css', exl: 'es' },
     fi: { ietf: 'fi-FI', tk: 'qxw8hzm.css' },
-    fr: { ietf: 'fr-FR', tk: 'hah7vzn.css' },
+    fr: { ietf: 'fr-FR', tk: 'hah7vzn.css', exl: 'fr' },
     gr_el: { ietf: 'el', tk: 'qxw8hzm.css' },
     gr_en: { ietf: 'en-GR', tk: 'hah7vzn.css' },
     gt: { ietf: 'es-419', tk: 'hah7vzn.css' },
     hk_en: { ietf: 'en-HK', tk: 'hah7vzn.css' },
-    hk_zh: { ietf: 'zh-HK', tk: 'jay0ecd' },
+    hk_zh: { ietf: 'zh-HK', tk: 'jay0ecd', exl: 'zh-hant' },
     hu: { ietf: 'hu-HU', tk: 'qxw8hzm.css' },
     id_en: { ietf: 'en', tk: 'hah7vzn.css' },
     id_id: { ietf: 'id', tk: 'qxw8hzm.css' },
@@ -152,48 +152,48 @@ const CONFIG = {
     il_he: { ietf: 'he', tk: 'qxw8hzm.css', dir: 'rtl' },
     in_hi: { ietf: 'hi', tk: 'qxw8hzm.css' },
     in: { ietf: 'en-IN', tk: 'hah7vzn.css' },
-    it: { ietf: 'it-IT', tk: 'hah7vzn.css' },
-    jp: { ietf: 'ja-JP', tk: 'dvg6awq' },
-    kr: { ietf: 'ko-KR', tk: 'qjs5sfm' },
+    it: { ietf: 'it-IT', tk: 'hah7vzn.css', exl: 'it' },
+    jp: { ietf: 'ja-JP', tk: 'dvg6awq', exl: 'ja' },
+    kr: { ietf: 'ko-KR', tk: 'qjs5sfm', exl: 'ko' },
     kw_ar: { ietf: 'ar', tk: 'qxw8hzm.css', dir: 'rtl' },
     kw_en: { ietf: 'en-GB', tk: 'hah7vzn.css' },
-    la: { ietf: 'es-LA', tk: 'hah7vzn.css' },
+    la: { ietf: 'es-LA', tk: 'hah7vzn.css', exl: 'es' },
     langstore: { ietf: 'en-US', tk: 'hah7vzn.css' },
     lt: { ietf: 'lt-LT', tk: 'qxw8hzm.css' },
-    lu_de: { ietf: 'de-LU', tk: 'hah7vzn.css' },
+    lu_de: { ietf: 'de-LU', tk: 'hah7vzn.css', exl: 'de' },
     lu_en: { ietf: 'en-LU', tk: 'hah7vzn.css' },
-    lu_fr: { ietf: 'fr-LU', tk: 'hah7vzn.css' },
+    lu_fr: { ietf: 'fr-LU', tk: 'hah7vzn.css', exl: 'fr' },
     lv: { ietf: 'lv-LV', tk: 'qxw8hzm.css' },
     mena_ar: { ietf: 'ar', tk: 'qxw8hzm.css', dir: 'rtl' },
     mena_en: { ietf: 'en', tk: 'hah7vzn.css' },
     mt: { ietf: 'en-MT', tk: 'hah7vzn.css' },
-    mx: { ietf: 'es-MX', tk: 'hah7vzn.css' },
+    mx: { ietf: 'es-MX', tk: 'hah7vzn.css', exl: 'es' },
     my_en: { ietf: 'en-GB', tk: 'hah7vzn.css' },
     my_ms: { ietf: 'ms', tk: 'qxw8hzm.css' },
     ng: { ietf: 'en-GB', tk: 'hah7vzn.css' },
-    nl: { ietf: 'nl-NL', tk: 'qxw8hzm.css' },
+    nl: { ietf: 'nl-NL', tk: 'qxw8hzm.css', exl: 'nl' },
     no: { ietf: 'no-NO', tk: 'qxw8hzm.css' },
     nz: { ietf: 'en-GB', tk: 'hah7vzn.css' },
-    pe: { ietf: 'es-PE', tk: 'hah7vzn.css' },
+    pe: { ietf: 'es-PE', tk: 'hah7vzn.css', exl: 'es' },
     ph_en: { ietf: 'en', tk: 'hah7vzn.css' },
     ph_fil: { ietf: 'fil-PH', tk: 'qxw8hzm.css' },
     pl: { ietf: 'pl-PL', tk: 'qxw8hzm.css' },
     pr: { ietf: 'es-419', tk: 'hah7vzn.css' },
-    pt: { ietf: 'pt-PT', tk: 'hah7vzn.css' },
+    pt: { ietf: 'pt-PT', tk: 'hah7vzn.css', exl: 'pt-br' },
     qa_ar: { ietf: 'ar', tk: 'qxw8hzm.css', dir: 'rtl' },
     qa_en: { ietf: 'en-GB', tk: 'hah7vzn.css' },
     ro: { ietf: 'ro-RO', tk: 'qxw8hzm.css' },
     ru: { ietf: 'ru-RU', tk: 'qxw8hzm.css' },
     sa_ar: { ietf: 'ar', tk: 'qxw8hzm.css', dir: 'rtl' },
     sa_en: { ietf: 'en', tk: 'hah7vzn.css' },
-    se: { ietf: 'sv-SE', tk: 'qxw8hzm.css' },
+    se: { ietf: 'sv-SE', tk: 'qxw8hzm.css', exl: 'sv' },
     sg: { ietf: 'en-SG', tk: 'hah7vzn.css' },
     si: { ietf: 'sl-SI', tk: 'qxw8hzm.css' },
     sk: { ietf: 'sk-SK', tk: 'qxw8hzm.css' },
     th_en: { ietf: 'en', tk: 'hah7vzn.css' },
     th_th: { ietf: 'th', tk: 'qxw8hzm.css' },
     tr: { ietf: 'tr-TR', tk: 'qxw8hzm.css' },
-    tw: { ietf: 'zh-TW', tk: 'jay0ecd' },
+    tw: { ietf: 'zh-TW', tk: 'jay0ecd', exl: 'zh-hant' },
     ua: { ietf: 'uk-UA', tk: 'qxw8hzm.css' },
     uk: { ietf: 'en-GB', tk: 'hah7vzn.css' },
     vn_en: { ietf: 'en-GB', tk: 'hah7vzn.css' },
@@ -211,6 +211,18 @@ const CONFIG = {
   stageDomainsMap: { 'business.stage.adobe.com': { 'business.adobe.com': 'origin' } },
   onlybanner: true,
 };
+
+export function transformExlLinks(locale, root = document) {
+  if (locale.ietf === 'en-US' || !locale.exl) return;
+  const exLinks = root.querySelectorAll('a[href*="experienceleague.adobe.com"]');
+  exLinks.forEach((link) => {
+    if (link.href.includes('#_dnt')) return;
+    if (link.href.includes('.html?lang=en')) {
+      link.href = link.href.replace('.html?lang=en', '').replace('https://experienceleague.adobe.com/', `https://experienceleague.adobe.com/${locale.exl}/`);
+    }
+    link.href = link.href.replace('/en/', `/${locale.exl}/`);
+  });
+}
 
 // Load LCP image immediately
 (function loadLCPImage() {
@@ -253,6 +265,7 @@ export async function loadPage() {
   const {
     loadArea,
     setConfig,
+    getLocale,
     loadLana,
     loadScript,
     loadStyle,
@@ -260,9 +273,12 @@ export async function loadPage() {
 
   detectSidekick({ loadScript, loadStyle });
 
-  setConfig({ ...CONFIG, miloLibs: LIBS });
+  const locale = getLocale(CONFIG.locales);
+  const decorateArea = (area) => { transformExlLinks(locale, area); };
+  setConfig({ ...CONFIG, decorateArea, miloLibs: LIBS });
   loadLana({ clientId: 'bacom-blog', tags: 'default', endpoint: 'https://business.adobe.com/lana/ll', endpointStage: 'https://business.stage.adobe.com/lana/ll' });
   await buildAutoBlocks();
+  transformExlLinks(locale);
   await loadArea();
 }
 

--- a/test/scripts/scripts.test.js
+++ b/test/scripts/scripts.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@esm-bundle/chai';
 import { readFile } from '@web/test-runner-commands';
 import sinon from 'sinon';
-import { setLibs, buildAutoBlocks } from '../../blog/scripts/scripts.js';
+import { setLibs, buildAutoBlocks, transformExlLinks } from '../../blog/scripts/scripts.js';
 
 describe('Libs', () => {
   it('Default Libs', () => {
@@ -43,6 +43,56 @@ describe('Libs', () => {
     };
     const libs = setLibs(location);
     expect(libs).to.equal('https://awesome--milo--forkedowner.aem.live/libs');
+  });
+});
+
+describe('Transform Experience League Links', () => {
+  it('does nothing for en-US locale', () => {
+    const locale = { ietf: 'en-US' };
+    const root = document.createElement('div');
+    root.innerHTML = '<a href="https://experienceleague.adobe.com/en/docs/thing">Link</a>';
+    transformExlLinks(locale, root);
+    expect(root.querySelector('a').href).to.equal('https://experienceleague.adobe.com/en/docs/thing');
+  });
+
+  it('does nothing for locale without exl mapping', () => {
+    const locale = { ietf: 'en-AU' };
+    const root = document.createElement('div');
+    root.innerHTML = '<a href="https://experienceleague.adobe.com/en/docs/thing">Link</a>';
+    transformExlLinks(locale, root);
+    expect(root.querySelector('a').href).to.equal('https://experienceleague.adobe.com/en/docs/thing');
+  });
+
+  it('transforms /en/ path segment to locale exl value', () => {
+    const locale = { ietf: 'fr-FR', exl: 'fr' };
+    const root = document.createElement('div');
+    root.innerHTML = '<a href="https://experienceleague.adobe.com/en/docs/experience-manager">Link</a>';
+    transformExlLinks(locale, root);
+    expect(root.querySelector('a').href).to.equal('https://experienceleague.adobe.com/fr/docs/experience-manager');
+  });
+
+  it('transforms .html?lang=en links', () => {
+    const locale = { ietf: 'de-DE', exl: 'de' };
+    const root = document.createElement('div');
+    root.innerHTML = '<a href="https://experienceleague.adobe.com/docs/thing.html?lang=en">Link</a>';
+    transformExlLinks(locale, root);
+    expect(root.querySelector('a').href).to.equal('https://experienceleague.adobe.com/de/docs/thing');
+  });
+
+  it('skips links with #_dnt', () => {
+    const locale = { ietf: 'fr-FR', exl: 'fr' };
+    const root = document.createElement('div');
+    root.innerHTML = '<a href="https://experienceleague.adobe.com/en/docs/thing#_dnt">Link</a>';
+    transformExlLinks(locale, root);
+    expect(root.querySelector('a').href).to.equal('https://experienceleague.adobe.com/en/docs/thing#_dnt');
+  });
+
+  it('transforms links in a custom root element (e.g. fragment content)', () => {
+    const locale = { ietf: 'fr-FR', exl: 'fr' };
+    const root = document.createElement('div');
+    root.innerHTML = '<a href="https://experienceleague.adobe.com/en/docs/experience-manager">Link</a>';
+    transformExlLinks(locale, root);
+    expect(root.querySelector('a').href).to.equal('https://experienceleague.adobe.com/fr/docs/experience-manager');
   });
 });
 


### PR DESCRIPTION
* Port Experience League link transformation from da-bacom
* Add `exl` locale codes to CONFIG locales for all supported non-en-US locales
* Add `transformExlLinks` function to rewrite `/en/` EXL paths to locale-specific equivalents
* Hook `transformExlLinks` into `decorateArea` so fragment content is also transformed

Resolves: [MWPW-197549](https://jira.corp.adobe.com/browse/MWPW-197549)

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://main--da-bacom-blog--adobecom.aem.live/jp/drafts/bmarshal/exl-link-test
- After: https://bmarshal-exp-league--da-bacom-blog--adobecom.aem.live/jp/drafts/bmarshal/exl-link-test